### PR TITLE
casecmp: char* alloc made conditional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .vscode/*
-.tests/test_execs/*
+tests/test_execs/*
 
 .DS_Store
 

--- a/src/diskfrisk.c
+++ b/src/diskfrisk.c
@@ -216,9 +216,8 @@ int entry_isvalid(char *fname)
 /* Compare user entry with filename using requested case-sensitivity */
 int casecmp(char *fname, char *entry_name)
 {  
-    char *cp;
-
     if (!option.csens) {
+        char *cp;
         for (cp = fname; *cp; ++cp)
             *cp = tolower(*cp);
         for(cp = entry_name; *cp; ++cp)


### PR DESCRIPTION
char *cp was unnecessarily allocated, only needed when condition is met.