### PR TITLE
sysdep bash open command

### DIFF
--- a/src/diskfrisk.c
+++ b/src/diskfrisk.c
@@ -61,7 +61,7 @@ char *input(int argc, char *argv[])
                     option.pmatch = 1;
                     break;
                 default:
-                    // Save illegal flag to HOMEpass in error message
+                    // Save illegal flag to pass in error message
                     x = c;
                     error.bad_flag = 1;
                     break;

--- a/src/sysdep.h
+++ b/src/sysdep.h
@@ -10,7 +10,7 @@
 #define HNAME     "Users"   // Home directory name
 #define HOME      "/Users"  // Home directory path
 #define ROOT      "/"       // Root directory path
-#define SHOPEN    "open "   // Open command
+#define SHOPEN    "open "   // Open command (space necessary for valid bash commands)
 #endif
 
 //Defining for compilation on Linux
@@ -19,7 +19,7 @@
 #define HNAME     "home"      // Home directory name
 #define HOME      "/home"     // Home directory path
 #define ROOT      "/"         // Root directory path
-#define SHOPEN    "xdg-open"  // Open command
+#define SHOPEN    "xdg-open " // Open command (space necessary for valid bash commands)
 #endif
 
 #endif


### PR DESCRIPTION
1. Whitespace necessary in `sysdep.h` to form a valid bash open file command.
2. Comment typo in `diskfrisk.c`